### PR TITLE
docs: adopt 3-pack build model - static, dockerfile, nixpacks

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -30,17 +30,32 @@ A URL-safe identifier derived from the App name, used for routing (`myapp.bigbos
 
 ### Framework Detection
 
-Auto-detection of the frontend framework by scanning `package.json` dependencies: `vite` → Vite, `react-scripts` → CRA, `next` → Next.js, `vue` → Vue. User can override any detected value.
+Handled by the **BuildPack** abstraction (`docs/adr/0012-build-pack-abstraction.md`). User selects a build pack at app creation time:
+
+- **`static`** — nginx:alpine. No detection. User provides output directory. Assets copied into image.
+- **`dockerfile`** — User provides Dockerfile in repo. No detection. Shipyard builds it.
+- **`nixpacks`** — Nixpacks auto-detects framework from repo contents (Node, Python, Go, Rust, etc.) and generates a Dockerfile. User can override build/start commands.
 
 ### Build Step
 
-An individual phase in the deployment pipeline:
+An individual phase in the deployment pipeline. The exact steps depend on the **build pack**:
 
+**Static build pack:**
 1. **Clone** — `git clone --depth 1`
-2. **Install** — `npm install`
-3. **Build** — `npm run build`
-4. **Verify** — check output directory exists and is not empty
-5. **Upload** — sync output to object storage
+2. **Build** — optional user-defined build command (e.g., `npm run build`)
+3. **Verify** — check output directory exists and not empty
+4. **Package** — copy assets into nginx:alpine image
+
+**Dockerfile build pack:**
+1. **Clone** — `git clone --depth 1`
+2. **Docker build** — `docker build -f Dockerfile`
+3. **Run** — start container, route traffic
+
+**Nixpacks build pack:**
+1. **Clone** — `git clone --depth 1`
+2. **Detect** — `nixpacks detect .` to detect framework
+3. **Docker build** — Nixpacks generates Dockerfile, then `docker build`
+4. **Run** — start container, route traffic
 
 ### Output Directory Verification Rules
 
@@ -71,7 +86,13 @@ When multiple git pushes arrive for the same App, the pending Build Job is cance
 
 ### Container Lifecycle
 
-Each build runs in an isolated `node:22-alpine` Docker container with 2GB memory limit and a 15-minute timeout. On success or failure, the container is immediately removed (`docker rm -f`). Logs are extracted before removal.
+Depends on the build pack:
+
+- **Static:** Build runs in a temporary build container (user-defined image or default). Output is packaged into an `nginx:alpine` runtime image. Long-lived.
+- **Dockerfile:** User's Dockerfile is built. Resulting image runs as a long-lived container.
+- **Nixpacks:** Nixpacks generates a Dockerfile. Image is built and runs as a long-lived container.
+
+All build containers have a 15-minute timeout. Runtime containers (static, dockerfile, nixpacks) are long-lived with health checks and automatic restarts.
 
 ## Storage & Routing
 

--- a/PRD.md
+++ b/PRD.md
@@ -6,7 +6,7 @@ Self-hosting static sites is painful. Existing tools either lock you into a SaaS
 
 ## Solution
 
-Shipyard is a self-hosted deployment control plane for static sites. It clones GitHub repos, runs builds in isolated Docker containers, uploads output to Garage, and routes traffic via Caddy. It is not a SaaS product — there are no quotas, no billing, no per-user limits. The only constraints are infrastructure-level (CPU, memory, disk). It is a Coolify-inspired deployment orchestrator scoped strictly to static sites.
+Shipyard is a self-hosted deployment control plane. It clones GitHub repos, builds projects using the selected **build pack** (static, Dockerfile, or Nixpacks), and runs the resulting containers with automatic routing via Caddy. It is not a SaaS product — there are no quotas, no billing, no per-user limits. The only constraints are infrastructure-level (CPU, memory, disk). It is a Coolify-inspired deployment orchestrator that grows from simple static sites to full application hosting.
 
 ## User Stories
 
@@ -21,13 +21,15 @@ Shipyard is a self-hosted deployment control plane for static sites. It clones G
 
 ### App Management
 
-1. As a developer, I want to create an app by connecting a GitHub repo, so that I can deploy it immediately.
-2. As a developer, I want the platform to auto-detect my framework (Vite, CRA, Next.js, Vue), so that build command and output directory are pre-filled.
-3. As a developer, I want to override the detected framework, build command, and output directory, so that I can handle non-standard setups.
-4. As a developer, I want to configure environment variables per app, so that secrets and config values are available at build time.
-5. As a developer, I want environment variables encrypted at rest (AES-256, key in env var), so that secrets are not stored in plaintext.
-6. As a developer, I want to see my apps on a dashboard with last deployment status, so that I can quickly see what is deployed.
-7. As a developer, I want to delete an app, so that I can clean up unused projects. Deleting an app removes all deployments from Garage storage and database records.
+1. As a developer, I want to choose a **build pack** (static, Dockerfile, or Nixpacks) when creating an app, so that Shipyard handles my project the right way.
+2. As a developer using the **static build pack**, I want to specify my output directory and optionally a build command, so that my pre-built assets are served via nginx.
+3. As a developer using the **Dockerfile build pack**, I want Shipyard to build my Dockerfile and run the resulting container, so that I can deploy any project with a custom Docker setup.
+4. As a developer using the **Nixpacks build pack**, I want the platform to auto-detect my framework and generate the Dockerfile, so that I don't have to write one manually.
+5. As a developer, I want to configure environment variables per app, so that secrets and config values are available at build and runtime.
+6. As a developer, I want environment variables encrypted at rest (AES-256, key in env var), so that secrets are not stored in plaintext.
+7. As a developer, I want to see my apps on a dashboard with deployment status and container health, so that I can quickly see what is running.
+8. As a developer, I want to configure the container port Shipyard routes traffic to, so that my app is accessible at the right endpoint.
+9. As a developer, I want to delete an app, so that I can clean up unused projects. Deleting an app stops the container and removes all database records.
 
 ### Deployments
 
@@ -174,10 +176,16 @@ apps
   description
   github_repo
   branch
+  build_pack (static | dockerfile | nixpacks)
   framework
   build_command
   output_directory
-  auto_deploy (boolean)
+  run_command
+  port (INTEGER, default 80)
+  dockerfile_path (VARCHAR, default './Dockerfile')
+  is_spa (BOOLEAN, default true)
+  custom_nginx_config (TEXT)
+  auto_deploy (BOOLEAN)
   active_deployment_id (FK → deployments, nullable)
   created_at
   updated_at
@@ -239,10 +247,12 @@ GET  /auth/github/callback     → Session cookie, redirect to dashboard
 GET  /auth/me                 → Current user
 
 GET  /apps                    → List org's apps
-POST /apps                    → Create app (connect repo)
-GET  /apps/:id               → App details
-PUT  /apps/:id               → Update settings
-DELETE /apps/:id             → Delete app
+POST /apps                    → Create app (connect repo + select build_pack)
+GET  /apps/:id               → App details including container status
+PUT  /apps/:id               → Update settings (build_pack, port, commands, etc.)
+DELETE /apps/:id             → Delete app (stop container, remove records)
+
+GET  /apps/:id/logs          → Stream container logs (SSE)
 
 GET  /apps/:id/deployments     → List app's deployments
 POST /apps/:id/deployments    → Trigger deploy
@@ -262,46 +272,66 @@ GET  /health                 → Health check
 
 ### Build Pipeline Flow
 
+The flow depends on the app's `build_pack`:
+
+**Static build pack:**
 ```
-1. Queue deployment job (deployment_id)
-2. Worker picks up job
-3. Update status: pending → building
-4. Clone repo (git clone --depth 1)
-   - Network timeout → retry 3x (exp backoff: 2s, 4s, 8s)
-   - Auth error (128) → fail immediately
-5. Inject env vars into container
-6. npm install
-   - Network timeout → retry 3x
-   - 404 Not Found → fail immediately
-   - ENOSPC → system alert, fail all
-7. npm run build
-   - Any non-zero exit → fail immediately
-8. Verify output directory exists and is not empty
-9. Upload to Garage (full upload in MVP)
-10. Keep newest 5 deployments, delete older ones
-11. Update active_deployment_id in apps
-12. Send config to Caddy API (auto-reloads)
-13. Update status: success
-14. docker rm -f (container)
+1. Clone repo (git clone --depth 1)
+2. (Optional) Run user-defined build command
+3. Verify output directory exists and not empty
+4. Build nginx:alpine image with assets copied to /usr/share/nginx/html/
+5. Deploy container (port 80)
+6. Send config to Caddy API (auto-reloads)
+7. Update status: success
+```
+
+**Dockerfile build pack:**
+```
+1. Clone repo (git clone --depth 1)
+2. docker build -f <dockerfile_path> -t shipyard-<id> .
+   - Build error → fail immediately
+3. Stop previous container (if any)
+4. Start new container from built image
+5. Health check → confirm container is responding
+6. Send config to Caddy API (route to new container)
+7. Update status: success
+```
+
+**Nixpacks build pack:**
+```
+1. Clone repo (git clone --depth 1)
+2. nixpacks build . --out ./Dockerfile
+   - Detection fail → fail with "could not detect framework"
+3. docker build -f ./Dockerfile -t shipyard-<id> .
+4. Stop previous container (if any)
+5. Start new container from built image
+6. Health check → confirm container is responding
+7. Send config to Caddy API (route to new container)
+8. Update status: success
 ```
 
 ### Caddy Configuration
 
 - Server blocks for `*.bigboss.dev` via Caddy's built-in auto-HTTPS (Let's Encrypt)
-- `reverse_proxy` to Garage endpoint
-- SPA fallback: Caddy `handle_errors` with rewrite to `/index.html`
+- Routes traffic based on build pack:
+  - **Static:** `reverse_proxy` to the nginx container
+  - **Dockerfile/Nixpacks:** `reverse_proxy` to the user's container on configured port
+- SPA fallback for static sites: Caddy `handle_errors` with rewrite to `/index.html`
 - JSON API config sent to `http://caddy:2019/config/`
-- S3 path style: `http://garage:3900/bucket/users/.../`
+- Each app gets a unique route — config updates are per-app (not full reload)
 
-### Docker Container
+### Docker Container (Runtime)
 
-- Image: `node:22-alpine`
-- Pre-installed: node, npm, git, build-essential, python3
-- Network: host or bridge (configurable)
-- Memory: 2GB limit
-- Timeout: 15 min (kill + fail if exceeded)
-- Cleanup: `docker rm -f` on success or failure
-- Startup: git clone → npm install → npm run build → extract dist
+Each deployed app runs as a long-lived Docker container:
+
+- Image: depends on build pack
+  - **Static:** `nginx:alpine` with user assets
+  - **Dockerfile:** user-provided Dockerfile output
+  - **Nixpacks:** Nixpacks-generated Dockerfile output
+- Network: bridge (configurable)
+- Restart policy: `unless-stopped`
+- Health check: configured per app
+- Logs: captured to database for streaming via API
 
 ### Env Var Encryption
 
@@ -338,26 +368,33 @@ The following are explicitly excluded from MVP and planned for v2 or later:
 - OpenTelemetry or distributed tracing
 - Database-level audit logging
 
-## Further Notes
+### Build Pack Implementation Order
 
-## Further Notes
+| Build Pack | When | Why |
+|---|---|---|
+| **Static** | P0 | Simplest. nginx:alpine, copy assets. Teaches the deployment pipeline. |
+| **Dockerfile** | P0 | Full control. Build any Dockerfile. Teaches container lifecycle. |
+| **Nixpacks** | P1 | Auto-detection. Requires nixpacks binary. Teaches framework abstraction. |
 
 ### MVP Priority Breakdown
 
-**P0 (Must Have - Week 1-4):**
+**P0 (Must Have):**
 - GitHub OAuth, app creation, manual deploy
-- Build pipeline with step-aware retry
-- Garage storage, Caddy routing, SPA fallback
-- Environment variables (encrypted)
-- Basic UI (app list, deploy button, logs view)
+- **Static build pack** — nginx:alpine, SPA fallback, custom nginx config
+- **Dockerfile build pack** — user-provided Dockerfile, port config, health checks
+- Container lifecycle (start, stop, restart, logs)
+- Caddy routing to containers (not just Garage)
+- Environment variables (encrypted, injected at build + runtime)
+- Basic UI (app list, create with build pack selector, deploy button, logs view)
 
-**P1 (Should Have - Week 5-6):**
+**P1 (Should Have):**
+- **Nixpacks build pack** — auto-detect framework, generate Dockerfile
 - Auto-deploy webhooks
 - Rollback
 - Build cancellation
 - Deployment history
 
-**P2 (Nice to Have - Post-MVP):**
+**P2 (Nice to Have):**
 - Rapid push debounce
 - Streaming build logs (SSE)
 - Worker heartbeat monitoring
@@ -373,7 +410,7 @@ The following are explicitly excluded from MVP and planned for v2 or later:
 
 After MVP, the natural expansion is:
 
-- **v2:** Custom domains + Let's Encrypt, webhook notifications, content hashing
+- **v2:** Custom domains + Let's Encrypt, webhook notifications, Nixpacks polish
 - **v3:** Teams + permissions, branch preview URLs, usage analytics
 
 ### Self-Hosted Model

--- a/docs/adr/0012-build-pack-abstraction.md
+++ b/docs/adr/0012-build-pack-abstraction.md
@@ -1,0 +1,99 @@
+# ADR-0012: Build Pack Abstraction — Static, Dockerfile, and Nixpacks
+
+## Status
+
+Accepted (updated)
+
+## Context
+
+The original Shipyard spec scoped the project to static sites only, with a simple `package.json` dependency scan for framework detection (Vite, CRA, Next.js, Vue). During triage of Issue #3 (app creation), two things became clear:
+
+1. The maintainer's goal is a general-purpose deployment platform (Coolify-like), not a static-site-only tool.
+2. Coolify itself uses a **build pack** model where users choose between Nixpacks (auto-detect), static (nginx), or Dockerfile (custom) at app creation time.
+
+Shipyard's build pipeline needs an abstraction that supports all three modes without coupling the deployment engine to any single strategy.
+
+## Decision
+
+### Build Pack Interface
+
+The deployment engine routes to one of three implementations based on the app's `build_pack` field:
+
+```typescript
+enum BuildPack {
+  Static = "static",       // nginx:alpine, copy static assets
+  Dockerfile = "dockerfile", // user-provided Dockerfile
+  Nixpacks = "nixpacks",    // Nixpacks auto-detect + Dockerfile generation
+}
+
+interface BuildPackResult {
+  imageName: string;       // Built Docker image name
+  containerPort: number;   // Port to expose (e.g., 80 for static, 3000 for Express)
+  outputDir?: string;      // For static: dir to pull assets from (optional)
+  healthCheck?: string;    // Optional health check path
+}
+```
+
+### Build Pack Implementations
+
+#### 1. Static Build Pack
+
+- **Base image:** `nginx:alpine`
+- **Flow:** Build → copy user's static assets from `output_dir` to `/usr/share/nginx/html/` → serve on port 80
+- **Config:** User specifies `output_dir` (default: `/dist`)
+- **Options:** SPA fallback mode (all 404s → index.html), custom nginx config
+- **No framework detection** — assumes pre-built assets. User runs their own build command if needed.
+
+#### 2. Dockerfile Build Pack
+
+- **Flow:** Git clone → `docker build -f Dockerfile` → `docker run` → route traffic to container
+- **Config:** User commits a `Dockerfile` in their repo. Shipyard builds it as-is.
+- **Port:** User configures the container port Shipyard should route to.
+- **No framework detection** — the Dockerfile defines everything.
+
+#### 3. Nixpacks Build Pack
+
+- **Flow:** Git clone → `nixpacks build .` (generates Dockerfile) → `docker build` → `docker run` → route traffic
+- **Detection:** Nixpacks auto-detects framework from repo contents (Next.js, Django, Rails, Go, etc.)
+- **Config:** User can override build/start commands. User specifies `output_dir` for static export frameworks.
+- **Dependency:** Requires `nixpacks` binary installed on the worker host.
+
+### User Configuration Per App
+
+| Field | Static | Dockerfile | Nixpacks |
+|-------|--------|------------|----------|
+| `build_pack` | `"static"` | `"dockerfile"` | `"nixpacks"` |
+| `output_dir` | Required (e.g., "dist") | N/A | Optional (for static exports) |
+| `build_command` | Optional | N/A | Override if needed |
+| `run_command` | N/A | N/A | Override if needed |
+| `port` | 80 (fixed) | Required (e.g., 3000) | Optional (auto-detected) |
+| `dockerfile_path` | N/A | Default: `./Dockerfile` | N/A |
+
+### Schema Changes
+
+Add to `apps` table:
+
+```sql
+build_pack VARCHAR(20) NOT NULL DEFAULT 'static',  -- 'static' | 'dockerfile' | 'nixpacks'
+run_command TEXT,                                    -- override for nixpacks
+port INTEGER DEFAULT 80,                             -- container port to route to
+dockerfile_path VARCHAR(255) DEFAULT './Dockerfile', -- for dockerfile pack
+is_spa BOOLEAN DEFAULT TRUE,                         -- SPA fallback for static pack
+custom_nginx_config TEXT,                            -- nginx override for static pack
+```
+
+## Consequences
+
+- **Three distinct build paths** share the same deployment state machine (pending → building → success/failed). Only the build execution differs.
+- **No migration cost** when adding a new build pack — implement the interface, add the enum value.
+- **Nixpacks is optional** — don't need the binary installed unless using that pack.
+- **Static pack stays lean** — no dependencies beyond nginx:alpine.
+- **Dockerfile pack is the escape hatch** — users who don't want auto-detection bring their own setup.
+- **Container routing required** — once you support dockerfile and nixpacks, you need to run long-lived containers and reverse-proxy to them, not just upload to Garage. This changes the Caddy routing architecture (ADR-0006 needs updating).
+
+## Alternatives Considered
+
+- **Static-site only (rejected):** Too narrow. The maintainer's goal is a general platform.
+- **Nixpacks only with static override (rejected):** Locks users into Nixpacks dependency even for simple static sites.
+- **Dockerfile only (rejected):** Too manual. No auto-detection, no static optimization.
+- **Two packs (static + dockerfile, no nixpacks) (rejected):** Nixpacks provides the "auto-detect everything" UX that makes Coolify compelling.


### PR DESCRIPTION
## Summary

- Expand project scope from static-site-only to general deployment platform (Coolify-like)
- Add ADR-0012 defining BuildPack interface with three implementations
- Update PRD.md with build pack user stories, schema fields, pipeline flows
- Update CONTEXT.md framework detection and build lifecycle sections
- Update Issue #3 scope to app creation shell + static build pack
- Create Issue #11 (Dockerfile build pack) and #12 (Nixpacks build pack)

## Decisions captured

| Decision | Detail |
|---|---|
| Build packs | static (nginx), dockerfile (user Dockerfile), nixpacks (auto-detect) |
| User config per app | output_dir, port, build_command, run_command, build_pack |
| Implementation order | Static P0 → Dockerfile P0 → Nixpacks P1 |
| Learning project | Not production — focus on breadth (containers, queues, auth, storage, routing) |

Closes triage session for #3.