### PR TITLE
docs(api): add JSDoc comments to all API route handlers

### DIFF
--- a/packages/api/src/routes/apps.ts
+++ b/packages/api/src/routes/apps.ts
@@ -11,6 +11,12 @@ export function createAppsRouter() {
 
 	router.use(requireAuth);
 
+	/**
+	 * List all apps in the authenticated user's organization.
+	 *
+	 * @auth Requires valid session cookie
+	 * @returns {Array<App>} 200 — array of app objects
+	 */
 	router.get("/", async (req, res) => {
 		try {
 			const apps = await appService.listApps(req.orgId!);
@@ -21,6 +27,15 @@ export function createAppsRouter() {
 		}
 	});
 
+	/**
+	 * Create a new app in the authenticated user's organization.
+	 *
+	 * @auth Requires valid session cookie
+	 * @param {object} req.body — app config validated by createAppSchema
+	 * @returns {App} 201 — created app object
+	 * @throws 400 — validation_error if body fails schema
+	 * @throws 409 — name_taken if app name already exists in org
+	 */
 	router.post("/", async (req, res) => {
 		try {
 			const parsed = createAppSchema.safeParse(req.body);
@@ -48,6 +63,14 @@ export function createAppsRouter() {
 		}
 	});
 
+	/**
+	 * Get a single app by ID within the authenticated user's organization.
+	 *
+	 * @auth Requires valid session cookie
+	 * @param {string} req.params.id — app ID
+	 * @returns {App} 200 — app object
+	 * @throws 404 — not_found if app does not exist
+	 */
 	router.get("/:id", async (req, res) => {
 		try {
 			const app = await appService.getApp(req.orgId!, req.params.id);
@@ -62,6 +85,17 @@ export function createAppsRouter() {
 		}
 	});
 
+	/**
+	 * Update an existing app by ID.
+	 *
+	 * @auth Requires valid session cookie
+	 * @param {string} req.params.id — app ID
+	 * @param {object} req.body — partial app fields validated by updateAppSchema
+	 * @returns {App} 200 — updated app object
+	 * @throws 400 — validation_error if body fails schema
+	 * @throws 404 — not_found if app does not exist
+	 * @throws 409 — name_taken if new name conflicts with another app
+	 */
 	router.put("/:id", async (req, res) => {
 		try {
 			const parsed = updateAppSchema.safeParse(req.body);
@@ -96,6 +130,15 @@ export function createAppsRouter() {
 		}
 	});
 
+	/**
+	 * Trigger a manual deployment for an app. Creates a deployment record
+	 * and enqueues a deploy job to the worker.
+	 *
+	 * @auth Requires valid session cookie
+	 * @param {string} req.params.id — app ID
+	 * @returns {Deployment} 201 — created deployment object
+	 * @throws 404 — not_found if app does not exist
+	 */
 	router.post("/:id/deployments", async (req, res) => {
 		try {
 			const app = await appService.getApp(req.orgId!, req.params.id);
@@ -127,6 +170,14 @@ export function createAppsRouter() {
 		}
 	});
 
+	/**
+	 * List all deployments for an app, most recent first.
+	 *
+	 * @auth Requires valid session cookie
+	 * @param {string} req.params.id — app ID
+	 * @returns {Array<Deployment>} 200 — array of deployment objects
+	 * @throws 404 — not_found if app does not exist
+	 */
 	router.get("/:id/deployments", async (req, res) => {
 		try {
 			const app = await appService.getApp(req.orgId!, req.params.id);
@@ -143,6 +194,14 @@ export function createAppsRouter() {
 		}
 	});
 
+	/**
+	 * Delete an app by ID.
+	 *
+	 * @auth Requires valid session cookie
+	 * @param {string} req.params.id — app ID
+	 * @returns {void} 204 — no content on success
+	 * @throws 404 — not_found if app does not exist
+	 */
 	router.delete("/:id", async (req, res) => {
 		try {
 			const deleted = await appService.deleteApp(req.orgId!, req.params.id);

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -17,6 +17,12 @@ import {
 export function createAuthRouter() {
 	const router = Router();
 
+	/**
+	 * Redirect the user to GitHub OAuth authorization page.
+	 *
+	 * @auth No auth required
+	 * @returns 302 — redirect to GitHub
+	 */
 	router.get("/github", (_req, res) => {
 		const env = getEnv();
 		const params = new URLSearchParams({
@@ -27,6 +33,16 @@ export function createAuthRouter() {
 		res.redirect(`https://github.com/login/oauth/authorize?${params}`);
 	});
 
+	/**
+	 * GitHub OAuth callback. Exchanges the code for an access token,
+	 * creates/updates the user and organization, sets a session cookie,
+	 * and redirects to the frontend dashboard.
+	 *
+	 * @auth No auth required (handles OAuth handshake)
+	 * @param {string} req.query.code — authorization code from GitHub
+	 * @returns 302 — redirect to dashboard on success, /login?error= on failure
+	 * @throws 500 — redirect to /login?error=auth_failed
+	 */
 	router.get("/github/callback", async (req, res) => {
 		const code = req.query.code as string | undefined;
 
@@ -60,6 +76,13 @@ export function createAuthRouter() {
 		}
 	});
 
+	/**
+	 * Get the currently authenticated user and their organization.
+	 * Returns null (not an error) when no valid session exists.
+	 *
+	 * @auth No auth required — returns null for unauthenticated requests
+	 * @returns {object} 200 — { user, organization } or null
+	 */
 	router.get("/me", async (req, res) => {
 		try {
 			const token = req.cookies?.session_token;
@@ -92,6 +115,13 @@ export function createAuthRouter() {
 		}
 	});
 
+	/**
+	 * Log out the current user by deleting their session and clearing
+	 * the session cookie.
+	 *
+	 * @auth No auth required — idempotent for unauthenticated requests
+	 * @returns {object} 200 — { success: true }
+	 */
 	router.post("/logout", async (req, res) => {
 		try {
 			const token = req.cookies?.session_token;

--- a/packages/api/src/routes/deployments.ts
+++ b/packages/api/src/routes/deployments.ts
@@ -9,6 +9,15 @@ export function createDeploymentsRouter() {
 
 	router.use(requireAuth);
 
+	/**
+	 * Get a single deployment by ID. Verifies the deployment's app
+	 * belongs to the authenticated user's organization.
+	 *
+	 * @auth Requires valid session cookie
+	 * @param {string} req.params.id — deployment ID
+	 * @returns {Deployment} 200 — deployment object
+	 * @throws 404 — not_found if deployment or its app does not exist
+	 */
 	router.get("/:id", async (req, res) => {
 		try {
 			const deployment = await deploymentService.getDeployment(req.params.id);

--- a/packages/api/src/routes/health.ts
+++ b/packages/api/src/routes/health.ts
@@ -6,6 +6,13 @@ import { redisHealthCheck } from "../plugins/redis.js";
 export function createHealthRouter(): Router {
 	const router = Router();
 
+	/**
+	 * Health check endpoint. Reports the status of the API server,
+	 * database, and Redis connections.
+	 *
+	 * @auth No auth required
+	 * @returns {object} 200 — { status, timestamp, environment, services: { database, redis } }
+	 */
 	router.get("/", async (_req, res) => {
 		const env = getEnv();
 		const dbStatus = await healthCheck()


### PR DESCRIPTION
## Summary

Closes #18. Adds JSDoc blocks to every Express route handler in the API.

### Files changed

- **packages/api/src/routes/apps.ts** — 7 handlers documented (list, create, get, update, trigger deploy, list deploys, delete)
- **packages/api/src/routes/auth.ts** — 4 handlers documented (github redirect, callback, me, logout)
- **packages/api/src/routes/deployments.ts** — 1 handler (get deployment detail)
- **packages/api/src/routes/health.ts** — 1 handler (health check)

Each block covers purpose, path params, auth requirement, success response shape, and error throws. No logic changes.