### PR TITLE
feat(api): add env var CRUD routes with AES-256-GCM encryption

### DIFF
--- a/packages/api/src/routes/apps.ts
+++ b/packages/api/src/routes/apps.ts
@@ -1,10 +1,20 @@
-import { createAppSchema, updateAppSchema } from "@shipyard/shared/validators";
+import type {
+	CreateEnvVarInput,
+	UpdateEnvVarInput,
+} from "@shipyard/shared/validators";
+import {
+	createAppSchema,
+	createEnvVarSchema,
+	updateAppSchema,
+	updateEnvVarSchema,
+} from "@shipyard/shared/validators";
 import { Router } from "express";
 import { logger } from "../config/logger.js";
 import { requireAuth } from "../middleware/auth.js";
 import { myQueue } from "../plugins/queue.js";
 import * as appService from "../services/apps.js";
 import * as deploymentService from "../services/deployments.js";
+import * as envVarService from "../services/env-vars.js";
 
 export function createAppsRouter() {
 	const router = Router();
@@ -190,6 +200,142 @@ export function createAppsRouter() {
 			res.json(list);
 		} catch (err) {
 			logger.error({ err }, "Failed to list deployments");
+			res.status(500).json({ error: "internal_error" });
+		}
+	});
+
+	/**
+	 * List all env vars for an app (values masked for secrets).
+	 *
+	 * @auth Requires valid session cookie
+	 * @param {string} req.params.id — app ID
+	 * @returns {Array<EnvVar>} 200 — array of env var objects with masked values
+	 * @throws 404 — not_found if app does not exist
+	 */
+	router.get("/:id/envvars", async (req, res) => {
+		try {
+			const app = await appService.getApp(req.orgId!, req.params.id);
+			if (!app) {
+				res.status(404).json({ error: "not_found" });
+				return;
+			}
+
+			const list = await envVarService.listEnvVars(req.params.id);
+			res.json(list);
+		} catch (err) {
+			logger.error({ err }, "Failed to list env vars");
+			res.status(500).json({ error: "internal_error" });
+		}
+	});
+
+	/**
+	 * Create a new env var for an app. Secret values are encrypted at rest.
+	 *
+	 * @auth Requires valid session cookie
+	 * @param {string} req.params.id — app ID
+	 * @param {object} req.body — { key, value, isSecret? }
+	 * @returns {EnvVar} 201 — created env var object (value masked if secret)
+	 * @throws 400 — validation_error if body fails schema
+	 * @throws 404 — not_found if app does not exist
+	 */
+	router.post("/:id/envvars", async (req, res) => {
+		try {
+			const app = await appService.getApp(req.orgId!, req.params.id);
+			if (!app) {
+				res.status(404).json({ error: "not_found" });
+				return;
+			}
+
+			const parsed = createEnvVarSchema.safeParse(req.body);
+			if (!parsed.success) {
+				res.status(400).json({
+					error: "validation_error",
+					details: parsed.error.flatten().fieldErrors,
+				});
+				return;
+			}
+
+			const envVar = await envVarService.createEnvVar(
+				req.params.id,
+				parsed.data as CreateEnvVarInput,
+			);
+			res.status(201).json(envVar);
+		} catch (err) {
+			logger.error({ err }, "Failed to create env var");
+			res.status(500).json({ error: "internal_error" });
+		}
+	});
+
+	/**
+	 * Update an existing env var.
+	 *
+	 * @auth Requires valid session cookie
+	 * @param {string} req.params.id — app ID
+	 * @param {string} req.params.envvarId — env var ID
+	 * @param {object} req.body — partial { key?, value?, isSecret? }
+	 * @returns {EnvVar} 200 — updated env var object
+	 * @throws 400 — validation_error if body fails schema
+	 * @throws 404 — not_found if app or env var does not exist
+	 */
+	router.put("/:id/envvars/:envvarId", async (req, res) => {
+		try {
+			const app = await appService.getApp(req.orgId!, req.params.id);
+			if (!app) {
+				res.status(404).json({ error: "not_found" });
+				return;
+			}
+
+			const parsed = updateEnvVarSchema.safeParse(req.body);
+			if (!parsed.success) {
+				res.status(400).json({
+					error: "validation_error",
+					details: parsed.error.flatten().fieldErrors,
+				});
+				return;
+			}
+
+			const envVar = await envVarService.updateEnvVar(
+				req.params.envvarId,
+				parsed.data as UpdateEnvVarInput,
+			);
+			if (!envVar) {
+				res.status(404).json({ error: "not_found" });
+				return;
+			}
+
+			res.json(envVar);
+		} catch (err) {
+			logger.error({ err }, "Failed to update env var");
+			res.status(500).json({ error: "internal_error" });
+		}
+	});
+
+	/**
+	 * Delete an env var.
+	 *
+	 * @auth Requires valid session cookie
+	 * @param {string} req.params.id — app ID
+	 * @param {string} req.params.envvarId — env var ID
+	 * @returns {void} 204 — no content on success
+	 * @throws 404 — not_found if app or env var does not exist
+	 */
+	router.delete("/:id/envvars/:envvarId", async (req, res) => {
+		try {
+			const app = await appService.getApp(req.orgId!, req.params.id);
+			if (!app) {
+				res.status(404).json({ error: "not_found" });
+				return;
+			}
+
+			const deleted = await envVarService.deleteEnvVar(req.params.envvarId);
+			if (!deleted) {
+				res.status(404).json({ error: "not_found" });
+				return;
+			}
+
+			res.status(204).send();
+		} catch (err) {
+			logger.error({ err }, "Failed to delete env var");
 			res.status(500).json({ error: "internal_error" });
 		}
 	});

--- a/packages/api/src/services/env-vars.ts
+++ b/packages/api/src/services/env-vars.ts
@@ -1,0 +1,99 @@
+import { envVars } from "@shipyard/shared/schema";
+import { encrypt } from "@shipyard/shared/utils";
+import type {
+	CreateEnvVarInput,
+	UpdateEnvVarInput,
+} from "@shipyard/shared/validators";
+import { eq } from "drizzle-orm";
+import { getEnv } from "../config/env.js";
+import { db } from "../plugins/db.js";
+
+const MASKED_VALUE = "*****";
+
+const safeColumns = {
+	id: envVars.id,
+	appId: envVars.appId,
+	key: envVars.key,
+	value: envVars.value,
+	isSecret: envVars.isSecret,
+	createdAt: envVars.createdAt,
+};
+
+function maskValue(row: typeof envVars.$inferSelect) {
+	return {
+		...row,
+		value: row.isSecret ? MASKED_VALUE : row.value,
+	};
+}
+
+export async function listEnvVars(appId: string) {
+	const rows = await db
+		.select(safeColumns)
+		.from(envVars)
+		.where(eq(envVars.appId, appId))
+		.orderBy(envVars.createdAt);
+	return rows.map(maskValue);
+}
+
+export async function createEnvVar(appId: string, input: CreateEnvVarInput) {
+	const env = getEnv();
+	const value = input.isSecret
+		? encrypt(input.value, env.ENCRYPTION_KEY)
+		: input.value;
+
+	const [row] = await db
+		.insert(envVars)
+		.values({
+			appId,
+			key: input.key,
+			value,
+			isSecret: input.isSecret,
+		})
+		.returning();
+
+	return maskValue(row);
+}
+
+export async function getEnvVar(envVarId: string) {
+	const rows = await db
+		.select(safeColumns)
+		.from(envVars)
+		.where(eq(envVars.id, envVarId));
+
+	const row = rows[0] ?? null;
+	return row ? maskValue(row) : null;
+}
+
+export async function updateEnvVar(envVarId: string, input: UpdateEnvVarInput) {
+	const env = getEnv();
+	const setData: Record<string, unknown> = {};
+
+	if (input.key !== undefined) setData.key = input.key;
+	if (input.isSecret !== undefined) setData.isSecret = input.isSecret;
+	if (input.value !== undefined) {
+		const isSecret = input.isSecret ?? true;
+		setData.value = isSecret
+			? encrypt(input.value, env.ENCRYPTION_KEY)
+			: input.value;
+	}
+
+	if (Object.keys(setData).length === 0) {
+		return getEnvVar(envVarId);
+	}
+
+	const [row] = await db
+		.update(envVars)
+		.set(setData)
+		.where(eq(envVars.id, envVarId))
+		.returning();
+
+	return row ? maskValue(row) : null;
+}
+
+export async function deleteEnvVar(envVarId: string) {
+	const rows = await db
+		.delete(envVars)
+		.where(eq(envVars.id, envVarId))
+		.returning({ id: envVars.id });
+	return rows.length > 0;
+}

--- a/packages/shared/src/validators/env-vars.ts
+++ b/packages/shared/src/validators/env-vars.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+export const envVarKeySchema = z
+	.string()
+	.min(1, "Key is required")
+	.max(255)
+	.regex(
+		/^[A-Za-z_][A-Za-z0-9_]*$/,
+		"Key must be alphanumeric + underscore only, starting with a letter or underscore",
+	);
+
+export const createEnvVarSchema = z.object({
+	key: envVarKeySchema,
+	value: z.string().min(1, "Value is required"),
+	isSecret: z.boolean().default(true),
+});
+
+export const updateEnvVarSchema = z.object({
+	key: envVarKeySchema.optional(),
+	value: z.string().optional(),
+	isSecret: z.boolean().optional(),
+});
+
+export type CreateEnvVarInput = z.infer<typeof createEnvVarSchema>;
+export type UpdateEnvVarInput = z.infer<typeof updateEnvVarSchema>;

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -1,3 +1,4 @@
 export * from "./app";
 export * from "./env";
+export * from "./env-vars";
 export * from "./githubAuth";


### PR DESCRIPTION
GET/POST/PUT/DELETE /api/apps/:id/envvars. Values encrypted at rest for secret vars, masked in API responses. Zod validates keys (alphanumeric + underscore). Build worker already handles decryption and injection — this completes the user-facing layer. Closes #7