### PR TITLE
feat(worker): prune old dockerfile image tags after successful deploy

### DIFF
--- a/packages/worker/src/deployments/deploy-dockerfile.ts
+++ b/packages/worker/src/deployments/deploy-dockerfile.ts
@@ -201,6 +201,9 @@ export async function deployDockerfile(
 			"Long-lived container started",
 		);
 
+		// Prune old image tags (best-effort)
+		await runner.pruneOldImageTags(app.id, imageTag);
+
 		// Step 5: Activate deployment
 		await db
 			.update(apps)

--- a/packages/worker/src/deployments/docker/docker-runner.ts
+++ b/packages/worker/src/deployments/docker/docker-runner.ts
@@ -435,8 +435,11 @@ export class DockerRunner {
 						try {
 							await this.docker.getImage(tag).remove();
 							logger.debug({ tag }, "Pruned old image tag");
-						} catch {
-							// 404 = already removed by concurrent prune
+						} catch (err: unknown) {
+							const statusCode = (err as Record<string, unknown>)?.statusCode;
+							if (statusCode !== 404) {
+								logger.warn({ err, tag }, "Failed to prune image tag");
+							}
 						}
 					}
 				}

--- a/packages/worker/src/deployments/docker/docker-runner.ts
+++ b/packages/worker/src/deployments/docker/docker-runner.ts
@@ -410,6 +410,43 @@ export class DockerRunner {
 	}
 
 	/**
+	 * Prunes old Docker image tags for an app, keeping only the current one.
+	 *
+	 * Each dockerfile deploy creates a new tag (shipyard-{appId}:{deploymentId}).
+	 * Docker's layer cache means all tags point at the same image, but old tags
+	 * accumulate unboundedly. This removes all tags for an app except the one
+	 * just created.
+	 *
+	 * Best-effort — errors are logged but not thrown. Handles concurrent
+	 * prunes gracefully (404 = already removed by another worker).
+	 *
+	 * @param appId - App ID used in the tag prefix
+	 * @param keepTag - Full image reference to keep (e.g. "shipyard-abc:deploy-123")
+	 */
+	async pruneOldImageTags(appId: string, keepTag: string): Promise<void> {
+		try {
+			const images = await this.docker.listImages({
+				filters: { reference: [`shipyard-${appId}`] },
+			});
+
+			for (const img of images) {
+				for (const tag of img.RepoTags ?? []) {
+					if (tag.startsWith(`shipyard-${appId}:`) && tag !== keepTag) {
+						try {
+							await this.docker.getImage(tag).remove();
+							logger.debug({ tag }, "Pruned old image tag");
+						} catch {
+							// 404 = already removed by concurrent prune
+						}
+					}
+				}
+			}
+		} catch (err) {
+			logger.warn({ err, appId }, "Failed to list images for pruning");
+		}
+	}
+
+	/**
 	 * Runs a command inside a build container.
 	 *
 	 * Streams stdout/stderr to the onData callback (for log capture),

--- a/packages/worker/test/unit/deploy-dockerfile.test.ts
+++ b/packages/worker/test/unit/deploy-dockerfile.test.ts
@@ -61,6 +61,7 @@ function makeDeps(selectResults?: unknown[][]) {
 		runLongLived: vi.fn().mockResolvedValue(43210),
 		stopByName: vi.fn().mockResolvedValue(undefined),
 		runOnce: vi.fn().mockResolvedValue(0),
+		pruneOldImageTags: vi.fn().mockResolvedValue(undefined),
 	};
 
 	const upsertFileRoute = vi.fn().mockResolvedValue(undefined);

--- a/packages/worker/test/unit/orchestrator.test.ts
+++ b/packages/worker/test/unit/orchestrator.test.ts
@@ -56,8 +56,9 @@ function makeDeps(selectResults?: unknown[][]) {
 		listManaged: vi.fn().mockResolvedValue([]),
 		inspect: vi.fn().mockResolvedValue({}),
 		buildImage: vi.fn().mockResolvedValue(undefined),
-		runLongLived: vi.fn().mockResolvedValue({ id: "long-lived-1" }),
+		runLongLived: vi.fn().mockResolvedValue(43210),
 		stopByName: vi.fn().mockResolvedValue(undefined),
+		pruneOldImageTags: vi.fn().mockResolvedValue(undefined),
 	};
 
 	const upsertFileRoute = vi.fn().mockResolvedValue(undefined);


### PR DESCRIPTION
closes #34 